### PR TITLE
Proof of concept showing how a PDF file could be merged with a PDF cover page

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,8 @@
   "homepage": "https://www.opus-repository.org",
   "require": {
     "opus4-repo/opus4-common": "dev-master",
-    "opus4-repo/framework": "dev-master"
+    "opus4-repo/framework": "dev-master",
+    "iio/libmergepdf": "^4.0"
   },
   "require-dev": {
     "phpunit/phpunit": "4.8.24",

--- a/composer.json
+++ b/composer.json
@@ -9,6 +9,8 @@
   ],
   "homepage": "https://www.opus-repository.org",
   "require": {
+    "opus4-repo/opus4-common": "dev-master",
+    "opus4-repo/framework": "dev-master"
   },
   "require-dev": {
     "phpunit/phpunit": "4.8.24",

--- a/src/Cover/CoverGeneratorFactory.php
+++ b/src/Cover/CoverGeneratorFactory.php
@@ -1,0 +1,74 @@
+<?php
+
+/**
+ * This file is part of OPUS. The software OPUS has been originally developed
+ * at the University of Stuttgart with funding from the German Research Net,
+ * the Federal Department of Higher Education and Research and the Ministry
+ * of Science, Research and the Arts of the State of Baden-Wuerttemberg.
+ *
+ * OPUS 4 is a complete rewrite of the original OPUS software and was developed
+ * by the Stuttgart University Library, the Library Service Center
+ * Baden-Wuerttemberg, the Cooperative Library Network Berlin-Brandenburg,
+ * the Saarland University and State Library, the Saxon State Library -
+ * Dresden State and University Library, the Bielefeld University Library and
+ * the University Library of Hamburg University of Technology with funding from
+ * the German Research Foundation and the European Regional Development Fund.
+ *
+ * LICENCE
+ * OPUS is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 2 of the Licence, or any later version.
+ * OPUS is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details. You should have received a copy of the GNU General Public License
+ * along with OPUS; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ * @copyright   Copyright (c) 2022, OPUS 4 development team
+ * @license     http://www.gnu.org/licenses/gpl.html General Public License
+ */
+
+namespace Opus\Pdf\Cover;
+
+use Opus\Config;
+use Opus\Util\ClassLoaderHelper;
+
+class CoverGeneratorFactory
+{
+    /**
+     * @return CoverGeneratorInterface|null
+     */
+    public static function create()
+    {
+        $config = Config::get();
+
+        $generatePdfCover = (isset($config->pdf->covers->generate)
+            && filter_var($config->pdf->covers->generate, FILTER_VALIDATE_BOOLEAN));
+
+        if (! $generatePdfCover) {
+            return null;
+        }
+
+        $generatorClass = 'Opus\Pdf\Cover\DefaultCoverGenerator'; // default class name
+
+        // TODO: allow to override the default cover generator class
+/*
+        if (isset($config->pdf->covers->generatorClass)) {
+            $generatorClass = $config->pdf->covers->generatorClass;
+        }
+*/
+
+        if (empty($generatorClass)) {
+            return null;
+        }
+
+        $classExists = ClassLoaderHelper::classExists($generatorClass);
+
+        if (! $classExists) {
+            return null;
+        }
+
+        return new $generatorClass();
+    }
+}

--- a/src/Cover/CoverGeneratorFactory.php
+++ b/src/Cover/CoverGeneratorFactory.php
@@ -44,15 +44,6 @@ class CoverGeneratorFactory
      */
     public static function create()
     {
-        $config = Config::get();
-
-        $generatePdfCover = (isset($config->pdf->covers->generate)
-            && filter_var($config->pdf->covers->generate, FILTER_VALIDATE_BOOLEAN));
-
-        if (! $generatePdfCover) {
-            return null;
-        }
-
         $generatorClass = 'Opus\Pdf\Cover\DefaultCoverGenerator'; // default class name
 
         // TODO: allow to override the default cover generator class

--- a/src/Cover/CoverGeneratorFactory.php
+++ b/src/Cover/CoverGeneratorFactory.php
@@ -34,6 +34,9 @@ namespace Opus\Pdf\Cover;
 use Opus\Config;
 use Opus\Util\ClassLoaderHelper;
 
+/**
+ * Factory to create a PDF cover generator instance.
+ */
 class CoverGeneratorFactory
 {
     /**

--- a/src/Cover/CoverGeneratorFactory.php
+++ b/src/Cover/CoverGeneratorFactory.php
@@ -31,7 +31,6 @@
 
 namespace Opus\Pdf\Cover;
 
-use Opus\Config;
 use Opus\Util\ClassLoaderHelper;
 
 /**

--- a/src/Cover/CoverGeneratorInterface.php
+++ b/src/Cover/CoverGeneratorInterface.php
@@ -42,8 +42,10 @@ interface CoverGeneratorInterface
      *
      * @param Document $document
      * @param File     $file
+     * @param string   $filecacheDir Path to a workspace subdirectory that stores cached document files.
+     * @param string   $tmpDir Path to a workspace subdirectory that stores temporary files.
      *
      * @return string file path
      */
-    public function processFile($document, $file);
+    public function processFile($document, $file, $filecacheDir, $tmpDir);
 }

--- a/src/Cover/CoverGeneratorInterface.php
+++ b/src/Cover/CoverGeneratorInterface.php
@@ -1,0 +1,49 @@
+<?php
+
+/**
+ * This file is part of OPUS. The software OPUS has been originally developed
+ * at the University of Stuttgart with funding from the German Research Net,
+ * the Federal Department of Higher Education and Research and the Ministry
+ * of Science, Research and the Arts of the State of Baden-Wuerttemberg.
+ *
+ * OPUS 4 is a complete rewrite of the original OPUS software and was developed
+ * by the Stuttgart University Library, the Library Service Center
+ * Baden-Wuerttemberg, the Cooperative Library Network Berlin-Brandenburg,
+ * the Saarland University and State Library, the Saxon State Library -
+ * Dresden State and University Library, the Bielefeld University Library and
+ * the University Library of Hamburg University of Technology with funding from
+ * the German Research Foundation and the European Regional Development Fund.
+ *
+ * LICENCE
+ * OPUS is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 2 of the Licence, or any later version.
+ * OPUS is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details. You should have received a copy of the GNU General Public License
+ * along with OPUS; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ * @copyright   Copyright (c) 2022, OPUS 4 development team
+ * @license     http://www.gnu.org/licenses/gpl.html General Public License
+ */
+
+namespace Opus\Pdf\Cover;
+
+use Opus\Document;
+use Opus\File;
+
+interface CoverGeneratorInterface
+{
+    /**
+     * Returns the file path to a file copy that includes an appropriate cover page.
+     * Returns the file's original path if cover generation fails.
+     *
+     * @param Document $document
+     * @param File     $file
+     *
+     * @return string file path
+     */
+    public function processFile($document, $file);
+}

--- a/src/Cover/CoverGeneratorInterface.php
+++ b/src/Cover/CoverGeneratorInterface.php
@@ -70,18 +70,18 @@ interface CoverGeneratorInterface
     public function setTempDir($tempDir);
 
     /**
-     * Returns the path to a workspace subdirectory that stores template files.
+     * Returns the path to a configuration directory that stores template files.
      *
      * @return string
      */
-    public function getTemplateDir();
+    public function getTemplatesDir();
 
     /**
-     * Sets the path to a workspace subdirectory that stores template files.
+     * Sets the path to a configuration directory that stores template files.
      *
-     * @param string $templateDir
+     * @param string $templatesDir
      */
-    public function setTemplateDir($templateDir);
+    public function setTemplatesDir($templatesDir);
 
     /**
      * Returns the file path to a file copy that includes an appropriate cover page.

--- a/src/Cover/CoverGeneratorInterface.php
+++ b/src/Cover/CoverGeneratorInterface.php
@@ -70,6 +70,20 @@ interface CoverGeneratorInterface
     public function setTempDir($tempDir);
 
     /**
+     * Returns the path to a workspace subdirectory that stores template files.
+     *
+     * @return string
+     */
+    public function getTemplateDir();
+
+    /**
+     * Sets the path to a workspace subdirectory that stores template files.
+     *
+     * @param string $templateDir
+     */
+    public function setTemplateDir($templateDir);
+
+    /**
      * Returns the file path to a file copy that includes an appropriate cover page.
      * Returns the file's original path if no cover needs to be generated or if cover generation fails.
      *

--- a/src/Cover/CoverGeneratorInterface.php
+++ b/src/Cover/CoverGeneratorInterface.php
@@ -34,14 +34,19 @@ namespace Opus\Pdf\Cover;
 use Opus\Document;
 use Opus\File;
 
+/**
+ * Interface for generating a PDF file copy which includes an appropriate PDF cover.
+ *
+ * The PDF cover should be generated via a PDF generator class that implements PdfGeneratorInterface.
+ */
 interface CoverGeneratorInterface
 {
     /**
      * Returns the file path to a file copy that includes an appropriate cover page.
-     * Returns the file's original path if cover generation fails.
+     * Returns the file's original path if no cover needs to be generated or if cover generation fails.
      *
-     * @param Document $document
-     * @param File     $file
+     * @param Document $document The document for which a PDF cover shall be generated.
+     * @param File     $file The document's file for which a PDF cover shall be generated.
      * @param string   $filecacheDir Path to a workspace subdirectory that stores cached document files.
      * @param string   $tmpDir Path to a workspace subdirectory that stores temporary files.
      *

--- a/src/Cover/CoverGeneratorInterface.php
+++ b/src/Cover/CoverGeneratorInterface.php
@@ -42,15 +42,41 @@ use Opus\File;
 interface CoverGeneratorInterface
 {
     /**
+     * Returns the path to a workspace subdirectory that stores cached document files.
+     *
+     * @return string
+     */
+    public function getFilecacheDir();
+
+    /**
+     * Sets the path to a workspace subdirectory that stores cached document files.
+     *
+     * @param string $filecacheDir
+     */
+    public function setFilecacheDir($filecacheDir);
+
+    /**
+     * Returns the path to a workspace subdirectory that stores temporary files.
+     *
+     * @return string
+     */
+    public function getTempDir();
+
+    /**
+     * Sets the path to a workspace subdirectory that stores temporary files.
+     *
+     * @param string $tempDir
+     */
+    public function setTempDir($tempDir);
+
+    /**
      * Returns the file path to a file copy that includes an appropriate cover page.
      * Returns the file's original path if no cover needs to be generated or if cover generation fails.
      *
      * @param Document $document The document for which a PDF cover shall be generated.
      * @param File     $file The document's file for which a PDF cover shall be generated.
-     * @param string   $filecacheDir Path to a workspace subdirectory that stores cached document files.
-     * @param string   $tmpDir Path to a workspace subdirectory that stores temporary files.
      *
      * @return string file path
      */
-    public function processFile($document, $file, $filecacheDir, $tmpDir);
+    public function processFile($document, $file);
 }

--- a/src/Cover/DefaultCoverGenerator.php
+++ b/src/Cover/DefaultCoverGenerator.php
@@ -195,7 +195,7 @@ class DefaultCoverGenerator implements CoverGeneratorInterface
     {
          $result = file_put_contents($filePath, $fileData);
 
-         return !($result === false);
+         return ! ($result === false);
     }
 
     /**

--- a/src/Cover/DefaultCoverGenerator.php
+++ b/src/Cover/DefaultCoverGenerator.php
@@ -48,7 +48,7 @@ class DefaultCoverGenerator implements CoverGeneratorInterface
 {
     private $filecacheDir = "";
     private $tempDir      = "";
-    private $templateDir  = "";
+    private $templatesDir = "";
 
     /**
      * Returns the path to a workspace subdirectory that stores cached document files.
@@ -95,25 +95,26 @@ class DefaultCoverGenerator implements CoverGeneratorInterface
     }
 
     /**
-     * Returns the path to a workspace subdirectory that stores template files.
+     * Returns the path to a configuration directory that stores template files.
      *
      * @return string
      */
-    public function getTemplateDir()
+    public function getTemplatesDir()
     {
-        // TODO: if $this->templateDir is empty, get the path to the template directory via Config::getInstance
+        // TODO: if $this->templatesDir is empty, get the path to the template directory via Config::getInstance
 
-        return $this->templateDir;
+        return $this->templatesDir;
     }
 
     /**
-     * Sets the path to a workspace subdirectory that stores template files.
+     * Sets the path to a configuration directory that stores template files.
      *
-     * @param string $templateDir
+     * @param string $templatesDir
      */
-    public function setTemplateDir($templateDir)
+    public function setTemplatesDir($templatesDir)
     {
-        $this->templateDir = $templateDir;
+        $this->templatesDir = $templatesDir;
+    }
     }
 
     /**

--- a/src/Cover/DefaultCoverGenerator.php
+++ b/src/Cover/DefaultCoverGenerator.php
@@ -47,7 +47,8 @@ use Opus\Pdf\Cover\PdfGenerator\PdfGeneratorInterface;
 class DefaultCoverGenerator implements CoverGeneratorInterface
 {
     private $filecacheDir = "";
-    private $tempDir = "";
+    private $tempDir      = "";
+    private $templateDir  = "";
 
     /**
      * Returns the path to a workspace subdirectory that stores cached document files.
@@ -91,6 +92,28 @@ class DefaultCoverGenerator implements CoverGeneratorInterface
     public function setTempDir($tempDir)
     {
         $this->tempDir = $tempDir;
+    }
+
+    /**
+     * Returns the path to a workspace subdirectory that stores template files.
+     *
+     * @return string
+     */
+    public function getTemplateDir()
+    {
+        // TODO: if $this->templateDir is empty, get the path to the template directory via Config::getInstance
+
+        return $this->templateDir;
+    }
+
+    /**
+     * Sets the path to a workspace subdirectory that stores template files.
+     *
+     * @param string $templateDir
+     */
+    public function setTemplateDir($templateDir)
+    {
+        $this->templateDir = $templateDir;
     }
 
     /**

--- a/src/Cover/DefaultCoverGenerator.php
+++ b/src/Cover/DefaultCoverGenerator.php
@@ -152,8 +152,8 @@ class DefaultCoverGenerator implements CoverGeneratorInterface
      */
     protected function getCachedFilename($file)
     {
-        // TODO: need to check for empty file path / parent ID values?
-        $filePath = $file->getPath();
+        // TODO: need to check for empty file name / parent ID values?
+        $filePath = $file->getPathName();
         $docId = $file->getParentId();
 
         $cachedFilename = $docId . '-' . $filePath;

--- a/src/Cover/DefaultCoverGenerator.php
+++ b/src/Cover/DefaultCoverGenerator.php
@@ -312,7 +312,7 @@ class DefaultCoverGenerator implements CoverGeneratorInterface
         $templateFormat        = null;
         $pdfEngine             = null;
 
-        if (substr($templatePath, -3) !== $markdownFileExtension) {
+        if (substr($templatePath, -3) === $markdownFileExtension) {
             $templateFormat = PdfGeneratorInterface::TEMPLATE_FORMAT_MARKDOWN;
             $pdfEngine      = PdfGeneratorInterface::PDF_ENGINE_XELATEX;
         }

--- a/src/Cover/DefaultCoverGenerator.php
+++ b/src/Cover/DefaultCoverGenerator.php
@@ -101,9 +101,13 @@ class DefaultCoverGenerator implements CoverGeneratorInterface
      */
     public function getTemplatesDir()
     {
-        // TODO: if $this->templatesDir is empty, get the path to the template directory via Config::getInstance
+        $templatesDir = $this->templatesDir;
 
-        return $this->templatesDir;
+        if (empty($templatesDir)) {
+            $templatesDir = APPLICATION_PATH . '/application/configs/covers';
+        }
+
+        return $templatesDir;
     }
 
     /**

--- a/src/Cover/DefaultCoverGenerator.php
+++ b/src/Cover/DefaultCoverGenerator.php
@@ -1,0 +1,126 @@
+<?php
+
+/**
+ * This file is part of OPUS. The software OPUS has been originally developed
+ * at the University of Stuttgart with funding from the German Research Net,
+ * the Federal Department of Higher Education and Research and the Ministry
+ * of Science, Research and the Arts of the State of Baden-Wuerttemberg.
+ *
+ * OPUS 4 is a complete rewrite of the original OPUS software and was developed
+ * by the Stuttgart University Library, the Library Service Center
+ * Baden-Wuerttemberg, the Cooperative Library Network Berlin-Brandenburg,
+ * the Saarland University and State Library, the Saxon State Library -
+ * Dresden State and University Library, the Bielefeld University Library and
+ * the University Library of Hamburg University of Technology with funding from
+ * the German Research Foundation and the European Regional Development Fund.
+ *
+ * LICENCE
+ * OPUS is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 2 of the Licence, or any later version.
+ * OPUS is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details. You should have received a copy of the GNU General Public License
+ * along with OPUS; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ * @copyright   Copyright (c) 2022, OPUS 4 development team
+ * @license     http://www.gnu.org/licenses/gpl.html General Public License
+ */
+
+namespace Opus\Pdf\Cover;
+
+use Opus\Document;
+use Opus\File;
+use Opus\Pdf\Cover\PdfGenerator\PdfGeneratorInterface;
+
+class DefaultCoverGenerator implements CoverGeneratorInterface
+{
+    /**
+     * Returns the file path to a file copy that includes an appropriate cover page.
+     * Returns the file's original path if cover generation fails.
+     *
+     * @param Document $document
+     * @param File     $file
+     *
+     * @return string file path
+     */
+    public function processFile($document, $file)
+    {
+        // TODO: if there's an up-to-date merged PDF for this file in workspace/filecache, return its path
+        // TODO: use getPdfGenerator() to get an appropriate PdfGenerator instance
+        // TODO: use the PdfGenerator instance to create a PDF cover (e.g. from a cover template)
+        // TODO: use saveCover() to save the generated PDF cover to workspace/tmp
+        // TODO: use mergeFileWithCover() to merge the PDF file with the PDF cover
+        $filePath = "";
+
+        return $filePath;
+    }
+
+    /**
+     * Returns true if there's an up-to-date file with a merged cover for the given file in workspace/filecache,
+     * otherwise returns false.
+     *
+     * @param File $file
+     *
+     * @return bool
+     */
+    protected function fileWithCoverExists($file)
+    {
+        // TODO: check if there's already an up-to-date merged PDF for this file in workspace/filecache
+
+        return false;
+    }
+
+    /**
+     * Returns a PDF generator instance to create a cover for the given document and file.
+     *
+     * @param Document $document
+     * @param File     $file
+     *
+     * @return PdfGeneratorInterface|null
+     */
+    protected function getPdfGenerator($document, $file)
+    {
+        // TODO: get a PdfGenerator instance that's appropriate for this document/file
+
+        return null;
+    }
+
+    /**
+     * Saves the generated cover to workspace/tmp.
+     *
+     * @param string $coverData
+     */
+    protected function saveCover($coverData)
+    {
+        // TODO: save the passed PDF cover data to workspace/tmp
+    }
+
+    /**
+     * Returns the original file data merged with the cover at the given path.
+     *
+     * @param File   $file
+     * @param string $coverPath Path to saved PDF cover file.
+     *
+     * @return string file data
+     */
+    protected function mergeFileWithCover($file, $coverPath)
+    {
+        // TODO: merge the given PDF file with the PDF cover at the given path
+        $fileData = "";
+
+        return $fileData;
+    }
+
+    /**
+     * Saves the file with merged cover to workspace/filecache.
+     *
+     * @param string $fileData
+     */
+    protected function saveFileWithCover($fileData)
+    {
+        // TODO: save the passed PDF data to workspace/filecache
+    }
+}

--- a/src/Cover/DefaultCoverGenerator.php
+++ b/src/Cover/DefaultCoverGenerator.php
@@ -38,6 +38,12 @@ use Opus\File;
 use Opus\Pdf\Cover\PdfGenerator\PdfGeneratorFactory;
 use Opus\Pdf\Cover\PdfGenerator\PdfGeneratorInterface;
 
+/**
+ * Generates a PDF file copy which includes an appropriate PDF cover.
+ *
+ * The generated file copy containing the PDF cover will be cached in a workspace subdirectory and served
+ * from this file cache unless a change of document metadata requires generating a new cover for the file.
+ */
 class DefaultCoverGenerator implements CoverGeneratorInterface
 {
     /**
@@ -172,6 +178,7 @@ class DefaultCoverGenerator implements CoverGeneratorInterface
     protected function getPdfGenerator($document, $file)
     {
         // TODO: get a PdfGenerator instance that's appropriate for this document/file
+        // TODO: configure PDF generator instance (e.g. with a template path) & return fully configured generator instance
 
         $generator = PdfGeneratorFactory::create();
 

--- a/src/Cover/DefaultCoverGenerator.php
+++ b/src/Cover/DefaultCoverGenerator.php
@@ -46,21 +46,66 @@ use Opus\Pdf\Cover\PdfGenerator\PdfGeneratorInterface;
  */
 class DefaultCoverGenerator implements CoverGeneratorInterface
 {
+    private $filecacheDir = "";
+    private $tempDir = "";
+
+    /**
+     * Returns the path to a workspace subdirectory that stores cached document files.
+     *
+     * @return string
+     */
+    public function getFilecacheDir()
+    {
+        // TODO: if $this->filecacheDir is empty, get the path to the filecache directory via Config::getInstance
+
+        return $this->filecacheDir;
+    }
+
+    /**
+     * Sets the path to a workspace subdirectory that stores cached document files.
+     *
+     * @param string $filecacheDir
+     */
+    public function setFilecacheDir($filecacheDir)
+    {
+        $this->filecacheDir = $filecacheDir;
+    }
+
+    /**
+     * Returns the path to a workspace subdirectory that stores temporary files.
+     *
+     * @return string
+     */
+    public function getTempDir()
+    {
+        // TODO: if $this->tempDir is empty, get the path to the temp directory via Config::getInstance
+
+        return $this->tempDir;
+    }
+
+    /**
+     * Sets the path to a workspace subdirectory that stores temporary files.
+     *
+     * @param string $tempDir
+     */
+    public function setTempDir($tempDir)
+    {
+        $this->tempDir = $tempDir;
+    }
+
     /**
      * Returns the file path to a file copy that includes an appropriate cover page.
      * Returns the file's original path if cover generation fails.
      *
      * @param Document $document
      * @param File     $file
-     * @param string   $filecacheDir Path to a workspace subdirectory that stores cached document files.
-     * @param string   $tmpDir Path to a workspace subdirectory that stores temporary files.
      *
      * @return string file path
      */
-    public function processFile($document, $file, $filecacheDir, $tmpDir)
+    public function processFile($document, $file)
     {
         $filePath = $file->getPath();
-        $cachedFilePath = $this->getCachedFilePath($file, $filecacheDir);
+        $cachedFilePath = $this->getCachedFilePath($file);
 
         if ($this->cachedFileExists($document, $file, $cachedFilePath)) {
             return $cachedFilePath;
@@ -72,7 +117,7 @@ class DefaultCoverGenerator implements CoverGeneratorInterface
         }
 
         // DEBUG
-        $coverPdfData = file_get_contents($filecacheDir . 'testcover.pdf'); // DEBUG
+        $coverPdfData = file_get_contents($this->getFilecacheDir() . 'testcover.pdf'); // DEBUG
 
         // TODO: use the PdfGenerator instance to create a PDF cover (e.g. from a cover template)
         // $coverPdfData = $pdfGenerator->generate();
@@ -80,7 +125,7 @@ class DefaultCoverGenerator implements CoverGeneratorInterface
             return $filePath;
         }
 
-        $coverPath = $this->getTmpFilePath($file, $tmpDir);
+        $coverPath = $this->getTempFilePath($file);
         $savedSuccessfully = $this->saveFileData($coverPdfData, $coverPath);
         if (! $savedSuccessfully) {
             return $filePath;
@@ -120,31 +165,29 @@ class DefaultCoverGenerator implements CoverGeneratorInterface
     /**
      * Returns the path of the cached file representing the given file in the filecache directory.
      *
-     * @param File   $file
-     * @param string $filecacheDir Path to a workspace subdirectory that stores cached document files.
+     * @param File $file
      *
      * @return string file path
      */
-    protected function getCachedFilePath($file, $filecacheDir)
+    protected function getCachedFilePath($file)
     {
         $cachedFilename = $this->getCachedFilename($file);
-        $cachedFilePath = $filecacheDir . $cachedFilename;
+        $cachedFilePath = $this->getFilecacheDir() . $cachedFilename;
 
         return $cachedFilePath;
     }
 
     /**
-     * Returns the path of the tmp file representing the given file in the tmp directory.
+     * Returns the path of the temp file representing the given file in the temp directory.
      *
-     * @param File   $file
-     * @param string $tmpDir Path to a workspace subdirectory that stores temporary files.
+     * @param File $file
      *
      * @return string file path
      */
-    protected function getTmpFilePath($file, $tmpDir)
+    protected function getTempFilePath($file)
     {
         $tmpFilename = $this->getCachedFilename($file);
-        $tmpFilePath = $tmpDir . $tmpFilename;
+        $tmpFilePath = $this->getTempDir() . $tmpFilename;
 
         return $tmpFilePath;
     }

--- a/src/Cover/PdfGenerator/DefaultPdfGenerator.php
+++ b/src/Cover/PdfGenerator/DefaultPdfGenerator.php
@@ -36,13 +36,35 @@ use Opus\Document;
 /**
  * Generates a PDF for a document based on a template.
  *
- * This default implementation uses pandoc and LaTeX to generate the PDF based on a Markdown template.
+ * This default implementation uses pandoc and XeTeX to generate the PDF based on a template file.
  *
  * For an existing instance of this class, the used template can be changed later on in order to achieve
  * a different PDF style.
  */
 class DefaultPdfGenerator implements PdfGeneratorInterface
 {
+    private $templatePath = "";
+
+    /**
+     * Returns the path to the template file that's used to generate the PDF.
+     *
+     * @return string
+     */
+    public function getTemplatePath()
+    {
+        return $this->templatePath;
+    }
+
+    /**
+     * Sets the path to the template file that's used to generate the PDF.
+     *
+     * @param string $templatePath
+     */
+    public function setTemplatePath($templatePath)
+    {
+        $this->templatePath = $templatePath;
+    }
+
     /**
      * Creates a PDF that's appropriate for the given document and returns the generated PDF data.
      * Returns null in case of failure.

--- a/src/Cover/PdfGenerator/DefaultPdfGenerator.php
+++ b/src/Cover/PdfGenerator/DefaultPdfGenerator.php
@@ -1,0 +1,47 @@
+<?php
+
+/**
+ * This file is part of OPUS. The software OPUS has been originally developed
+ * at the University of Stuttgart with funding from the German Research Net,
+ * the Federal Department of Higher Education and Research and the Ministry
+ * of Science, Research and the Arts of the State of Baden-Wuerttemberg.
+ *
+ * OPUS 4 is a complete rewrite of the original OPUS software and was developed
+ * by the Stuttgart University Library, the Library Service Center
+ * Baden-Wuerttemberg, the Cooperative Library Network Berlin-Brandenburg,
+ * the Saarland University and State Library, the Saxon State Library -
+ * Dresden State and University Library, the Bielefeld University Library and
+ * the University Library of Hamburg University of Technology with funding from
+ * the German Research Foundation and the European Regional Development Fund.
+ *
+ * LICENCE
+ * OPUS is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 2 of the Licence, or any later version.
+ * OPUS is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details. You should have received a copy of the GNU General Public License
+ * along with OPUS; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ * @copyright   Copyright (c) 2022, OPUS 4 development team
+ * @license     http://www.gnu.org/licenses/gpl.html General Public License
+ */
+
+namespace Opus\Pdf\Cover\PdfGenerator;
+
+class DefaultPdfGenerator implements PdfGeneratorInterface
+{
+    /**
+     * Creates a PDF cover based on the configuration settings.
+     *
+     * @return string|null
+     */
+    public function generate()
+    {
+        // TODO: generate PDF cover from cover template
+
+        return null;
+    }
+}

--- a/src/Cover/PdfGenerator/DefaultPdfGenerator.php
+++ b/src/Cover/PdfGenerator/DefaultPdfGenerator.php
@@ -34,9 +34,9 @@ namespace Opus\Pdf\Cover\PdfGenerator;
 class DefaultPdfGenerator implements PdfGeneratorInterface
 {
     /**
-     * Creates a PDF cover based on the configuration settings.
+     * Creates a PDF cover based on this class's configuration.
      *
-     * @return string|null
+     * @return string|null Generated PDF data.
      */
     public function generate()
     {

--- a/src/Cover/PdfGenerator/DefaultPdfGenerator.php
+++ b/src/Cover/PdfGenerator/DefaultPdfGenerator.php
@@ -31,16 +31,29 @@
 
 namespace Opus\Pdf\Cover\PdfGenerator;
 
+use Opus\Document;
+
+/**
+ * Generates a PDF for a document based on a template.
+ *
+ * This default implementation uses pandoc and LaTeX to generate the PDF based on a Markdown template.
+ *
+ * For an existing instance of this class, the used template can be changed later on in order to achieve
+ * a different PDF style.
+ */
 class DefaultPdfGenerator implements PdfGeneratorInterface
 {
     /**
-     * Creates a PDF cover based on this class's configuration.
+     * Creates a PDF that's appropriate for the given document and returns the generated PDF data.
+     * Returns null in case of failure.
+     *
+     * @param Document $document The document for which a PDF shall be generated.
      *
      * @return string|null Generated PDF data.
      */
-    public function generate()
+    public function generate($document)
     {
-        // TODO: generate PDF cover from cover template
+        // TODO: generate PDF from template
 
         return null;
     }

--- a/src/Cover/PdfGenerator/PdfGeneratorFactory.php
+++ b/src/Cover/PdfGenerator/PdfGeneratorFactory.php
@@ -1,0 +1,49 @@
+<?php
+
+/**
+ * This file is part of OPUS. The software OPUS has been originally developed
+ * at the University of Stuttgart with funding from the German Research Net,
+ * the Federal Department of Higher Education and Research and the Ministry
+ * of Science, Research and the Arts of the State of Baden-Wuerttemberg.
+ *
+ * OPUS 4 is a complete rewrite of the original OPUS software and was developed
+ * by the Stuttgart University Library, the Library Service Center
+ * Baden-Wuerttemberg, the Cooperative Library Network Berlin-Brandenburg,
+ * the Saarland University and State Library, the Saxon State Library -
+ * Dresden State and University Library, the Bielefeld University Library and
+ * the University Library of Hamburg University of Technology with funding from
+ * the German Research Foundation and the European Regional Development Fund.
+ *
+ * LICENCE
+ * OPUS is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 2 of the Licence, or any later version.
+ * OPUS is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details. You should have received a copy of the GNU General Public License
+ * along with OPUS; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ * @copyright   Copyright (c) 2022, OPUS 4 development team
+ * @license     http://www.gnu.org/licenses/gpl.html General Public License
+ */
+
+namespace Opus\Pdf\Cover\PdfGenerator;
+
+class PdfGeneratorFactory
+{
+    /**
+     * @return PdfGeneratorInterface|null
+     */
+    public static function create()
+    {
+        // TODO: allow to use diff. PDF generator classes with diff. templates depending on the doc's collection
+        //       possible config setting to get the template for a collection: pdf.covers.<COLLECTIONID> = <TEMPLATENAME>
+        // $config = Config::get();
+
+        // TODO: configure PDF generator instance (e.g. with a template path) & return fully configured generator instance
+
+        return new DefaultPdfGenerator();
+    }
+}

--- a/src/Cover/PdfGenerator/PdfGeneratorFactory.php
+++ b/src/Cover/PdfGenerator/PdfGeneratorFactory.php
@@ -31,20 +31,41 @@
 
 namespace Opus\Pdf\Cover\PdfGenerator;
 
+use Opus\Util\ClassLoaderHelper;
+
 /**
  * Factory to create a PDF generator instance.
  */
 class PdfGeneratorFactory
 {
     /**
+     * @param string $templateFormat The template format to be used with the returned PDF generator.
+     * @param string $pdfEngine The PDF engine to be used by the returned PDF generator.
+     *
      * @return PdfGeneratorInterface|null
      */
-    public static function create()
+    public static function create($templateFormat, $pdfEngine)
     {
-        // TODO: allow to use diff. PDF generator classes with diff. templates depending on the doc's collection
-        //       possible config setting to get the template for a collection: collection.<COLLECTIONID>.cover = <TEMPLATENAME>
-        // $config = Config::get();
+        // TODO: support more template format(s) and PDF engine(s) via different PdfGeneratorInterface implementation(s)
 
-        return new DefaultPdfGenerator();
+        $generatorClass = null;
+
+        if ($templateFormat === PdfGeneratorInterface::TEMPLATE_FORMAT_MARKDOWN &&
+            $pdfEngine === PdfGeneratorInterface::PDF_ENGINE_XELATEX) {
+            $generatorClass = 'Opus\Pdf\Cover\PdfGenerator\DefaultPdfGenerator';
+        }
+
+        if (empty($generatorClass)) {
+            return null;
+        }
+
+        $classExists = ClassLoaderHelper::classExists($generatorClass);
+
+        if (! $classExists) {
+            return null;
+        }
+
+        return new $generatorClass();
+
     }
 }

--- a/src/Cover/PdfGenerator/PdfGeneratorFactory.php
+++ b/src/Cover/PdfGenerator/PdfGeneratorFactory.php
@@ -31,6 +31,9 @@
 
 namespace Opus\Pdf\Cover\PdfGenerator;
 
+/**
+ * Factory to create a PDF generator instance.
+ */
 class PdfGeneratorFactory
 {
     /**
@@ -39,10 +42,8 @@ class PdfGeneratorFactory
     public static function create()
     {
         // TODO: allow to use diff. PDF generator classes with diff. templates depending on the doc's collection
-        //       possible config setting to get the template for a collection: pdf.covers.<COLLECTIONID> = <TEMPLATENAME>
+        //       possible config setting to get the template for a collection: collection.<COLLECTIONID>.cover = <TEMPLATENAME>
         // $config = Config::get();
-
-        // TODO: configure PDF generator instance (e.g. with a template path) & return fully configured generator instance
 
         return new DefaultPdfGenerator();
     }

--- a/src/Cover/PdfGenerator/PdfGeneratorInterface.php
+++ b/src/Cover/PdfGenerator/PdfGeneratorInterface.php
@@ -40,6 +40,24 @@ use Opus\Document;
  */
 interface PdfGeneratorInterface
 {
+    // TODO: add constants for other supported template formats & PDF engines
+    const TEMPLATE_FORMAT_MARKDOWN = 'markdown';
+    const PDF_ENGINE_XELATEX       = 'xelatex';
+
+    /**
+     * Returns the path to the template file that's used to generate the PDF.
+     *
+     * @return string
+     */
+    public function getTemplatePath();
+
+    /**
+     * Sets the path to the template file that's used to generate the PDF.
+     *
+     * @param string $templatePath
+     */
+    public function setTemplatePath($templatePath);
+
     /**
      * Creates a PDF that's appropriate for the given document and returns the generated PDF data.
      * Returns null in case of failure.

--- a/src/Cover/PdfGenerator/PdfGeneratorInterface.php
+++ b/src/Cover/PdfGenerator/PdfGeneratorInterface.php
@@ -31,12 +31,22 @@
 
 namespace Opus\Pdf\Cover\PdfGenerator;
 
+use Opus\Document;
+
+/**
+ * Interface for generating a PDF for a document based on a template.
+ *
+ * Different implementations of this interface may use different tool chains to generate the PDF.
+ */
 interface PdfGeneratorInterface
 {
     /**
-     * Creates a PDF file and returns the generated PDF data. Returns null in case of failure.
+     * Creates a PDF that's appropriate for the given document and returns the generated PDF data.
+     * Returns null in case of failure.
+     *
+     * @param Document $document The document for which a PDF shall be generated.
      *
      * @return string|null Generated PDF data.
      */
-    public function generate();
+    public function generate($document);
 }

--- a/src/Cover/PdfGenerator/PdfGeneratorInterface.php
+++ b/src/Cover/PdfGenerator/PdfGeneratorInterface.php
@@ -1,0 +1,42 @@
+<?php
+
+/**
+ * This file is part of OPUS. The software OPUS has been originally developed
+ * at the University of Stuttgart with funding from the German Research Net,
+ * the Federal Department of Higher Education and Research and the Ministry
+ * of Science, Research and the Arts of the State of Baden-Wuerttemberg.
+ *
+ * OPUS 4 is a complete rewrite of the original OPUS software and was developed
+ * by the Stuttgart University Library, the Library Service Center
+ * Baden-Wuerttemberg, the Cooperative Library Network Berlin-Brandenburg,
+ * the Saarland University and State Library, the Saxon State Library -
+ * Dresden State and University Library, the Bielefeld University Library and
+ * the University Library of Hamburg University of Technology with funding from
+ * the German Research Foundation and the European Regional Development Fund.
+ *
+ * LICENCE
+ * OPUS is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 2 of the Licence, or any later version.
+ * OPUS is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details. You should have received a copy of the GNU General Public License
+ * along with OPUS; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ * @copyright   Copyright (c) 2022, OPUS 4 development team
+ * @license     http://www.gnu.org/licenses/gpl.html General Public License
+ */
+
+namespace Opus\Pdf\Cover\PdfGenerator;
+
+interface PdfGeneratorInterface
+{
+    /**
+     * Creates a PDF file and returns the generated PDF data. Returns null in case of failure.
+     *
+     * @return string|null Generated PDF data.
+     */
+    public function generate();
+}


### PR DESCRIPTION
Interim-PR for OPUS4/application#453.

**NOTE**: For now, the PDF generator class isn't really used yet. Instead, there's some DEBUG code (see `DefaultCoverGenerator:69`) which still requires a dummy PDF cover to be located at `workspace/filecache/testcover.pdf`.
