### PR TITLE
Die `cover:generate --template` Kommando-Option akzeptiert auch Dateinamen

### DIFF
--- a/src/Console/CoverGenerateCommand.php
+++ b/src/Console/CoverGenerateCommand.php
@@ -71,7 +71,7 @@ class CoverGenerateCommand extends Command
         $help = <<<EOT
 The <fg=green>cover:generate</> command can be used to generate a PDF cover for a single document.
 
-If no <fg=green>out</> file (*.pdf) is given the output file name will be "DOCUMENT_ID.pdf".
+If no <fg=green>out</> file (*.pdf) is given the output file name will be "\<DocID\>.pdf".
 
 If no <fg=green>template</> path is provided or the given path doesn't exist, the default template that's
 appropriate for the specified document will be used.
@@ -112,12 +112,8 @@ EOT;
     {
         // TODO Support other PDF generator implementations
 
-        $docId      = $input->getArgument(self::ARGUMENT_DOC_ID);
-        $outputName = $input->getOption(self::OPTION_OUTPUT_FILE);
-
-        // TODO '--template' option should support specifying just the name of a template like in the configuration
-        //      for collections. It should not be necessary to specify full paths, although this can be supported
-        //      additionally.
+        $docId        = $input->getArgument(self::ARGUMENT_DOC_ID);
+        $outputName   = $input->getOption(self::OPTION_OUTPUT_FILE);
         $templatePath = $input->getOption(self::OPTION_TEMPLATE_PATH);
 
         $coverGenerator = new DefaultCoverGenerator();

--- a/src/Cover/DefaultCoverGenerator.php
+++ b/src/Cover/DefaultCoverGenerator.php
@@ -258,7 +258,7 @@ class DefaultCoverGenerator implements CoverGeneratorInterface
             return $cachedFilePath;
         }
 
-        $pdfGenerator = $this->getPdfGenerator($document, $file);
+        $pdfGenerator = $this->getPdfGenerator($document);
         if ($pdfGenerator === null) {
             return $filePath;
         }

--- a/src/Cover/DefaultCoverGenerator.php
+++ b/src/Cover/DefaultCoverGenerator.php
@@ -213,8 +213,9 @@ class DefaultCoverGenerator implements CoverGeneratorInterface
      * Returns null if cover generation fails.
      *
      * @param int         $documentId Id of the document for which a cover shall be generated.
-     * @param string|null $templatePath (Optional) The absolute path to the template file to be used. If not given
-     * or the path doesn't exist, the default template that's appropriate for the given document will be used.
+     * @param string|null $templatePath (Optional) The absolute path (or path relative to the templates directory) of
+     * the template file to be used. If not given or the path doesn't exist, the default template that's appropriate
+     * for the given document will be used.
      * @return string|null File path.
      *
      * TODO DocumentInterface object should not be instantiated here
@@ -480,15 +481,21 @@ class DefaultCoverGenerator implements CoverGeneratorInterface
      * Returns a PDF generator instance to create a cover for the given document.
      *
      * @param DocumentInterface $document The document for which a cover shall be created.
-     * @param string|null       $templatePath (Optional) The absolute path to the template file to be used. If not
-     * given or the path doesn't exist, the default template that's appropriate for the given document will be used.
+     * @param string|null       $templatePath (Optional) The absolute path (or path relative to the templates directory)
+     * of the template file to be used. If not given or the path doesn't exist, the default template that's appropriate
+     * for the given document will be used.
      * @return PdfGeneratorInterface|null
      */
     protected function getPdfGenerator($document, $templatePath = null)
     {
         // TODO support more template format(s) and PDF engine(s) via different PdfGeneratorInterface implementation(s)
 
+        if ($templatePath !== null && ! file_exists($templatePath)) {
+            // look for given template file in default template directory
+            $templatePath = $this->getTemplatesDir() . $templatePath;
+        }
         if ($templatePath === null || ! file_exists($templatePath)) {
+            // use the document's default template
             $templatePath = $this->getTemplatePath($document);
         }
         if ($templatePath === null) {


### PR DESCRIPTION
PR für #52 .

Die `cover:generate --template` Kommando-Option akzeptiert neben einem absoluten Pfad nun auch einen Dateinamen bzw. Pfad relativ zum Standard-Vorlagen-Verzeichnis.